### PR TITLE
PHP 8.0 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /laminas-mkdoc-theme.tgz
 /laminas-mkdoc-theme/
 /vendor/
+/.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@
 /laminas-mkdoc-theme.tgz
 /laminas-mkdoc-theme/
 /vendor/
-/.idea/

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ env:
 
 matrix:
   fast_finish: true
+  allow_failures:
+    - php: 8.0
   include:
     - php: 5.6
       env:
@@ -51,7 +53,9 @@ matrix:
         - DEPS=latest
         - CS_CHECK=true
         - TEST_COVERAGE=true
-
+    - php: 8.0
+      env:
+        - DEPS=latest
 before_install:
   - if [[ $TEST_COVERAGE != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,30 +15,6 @@ matrix:
   allow_failures:
     - php: 8.0
   include:
-    - php: 5.6
-      env:
-        - DEPS=lowest
-    - php: 5.6
-      env:
-        - DEPS=latest
-    - php: 7.0
-      env:
-        - DEPS=lowest
-    - php: 7.0
-      env:
-        - DEPS=latest
-    - php: 7.1
-      env:
-        - DEPS=lowest
-    - php: 7.1
-      env:
-        - DEPS=latest
-    - php: 7.2
-      env:
-        - DEPS=lowest
-    - php: 7.2
-      env:
-        - DEPS=latest
     - php: 7.3
       env:
         - DEPS=lowest

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ before_install:
 install:
   - travis_retry composer install $COMPOSER_ARGS --ignore-platform-reqs
   - travis_retry composer require --dev --no-update $COMPOSER_ARGS $SERIALIZER_DEPS
-  - if [[ $DEPS == 'latest' ]]; then travis_retry composer update $COMPOSER_ARGS ; fi
+  - if [[ $DEPS == 'latest' ]]; then travis_retry composer update $COMPOSER_ARGS --ignore-platform-reqs; fi
   - if [[ $DEPS == 'lowest' ]]; then travis_retry composer update --prefer-lowest --prefer-stable $COMPOSER_ARGS ; fi
   - if [[ $TEST_COVERAGE == 'true' ]]; then travis_retry composer require --dev $COMPOSER_ARGS $COVERAGE_DEPS ; fi
   - stty cols 120 && composer show

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,6 @@ env:
 
 matrix:
   fast_finish: true
-  allow_failures:
-    - php: 8.0
   include:
     - php: 7.3
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ matrix:
         - DEPS=latest
         - CS_CHECK=true
         - TEST_COVERAGE=true
+        - XDEBUG_MODE=coverage
     - php: 8.0
       env:
         - DEPS=latest

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     ],
     "license": "BSD-3-Clause",
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.3 || ~8.0.0",
         "laminas/laminas-cache": "^2.10@dev"
     },
     "provide": {


### PR DESCRIPTION
Add PHP 8.0 support #2

- [x] Modify composer.json to provide support for PHP 8.0 by adding the constraint ~8.0.0
- [x] Modify composer.json to drop support for PHP less than 7.3
- [ ] Modify composer.json to implement phpunit 9.3 which supports PHP 7.3+
  * Is `laminas/laminas-cache-storage-adapter-test` ready for phpunit 9.x?
- [x] Modify .travis.yml to ignore platform requirements when installing composer dependencies (simply add --ignore-platform-reqs to COMPOSER_ARGS env variable)
- [ ] ~~Modify .travis.yml to add PHP 8.0 to the matrix (NOTE: Do not allow failures as PHP 8.0 has a feature freeze since 2020-08-04!)~~
- [x] Modify source code in case there are incompatibilities with PHP 8.0
  * Codesniffer PHPCompatibility Error Report: No errors found

The build is now working. 

There is only a DCO error. How can I  sign off correctly?

I get this error: 

```
git rebase HEAD~5 --signoff
error: unknown option `signoff'
```

