### PR TITLE
Do not set cacheDir null if cacheDir exists in $options.

### DIFF
--- a/src/FilesystemOptions.php
+++ b/src/FilesystemOptions.php
@@ -127,7 +127,9 @@ final class FilesystemOptions extends AdapterOptions
             $this->dirPermission  = false;
         }
 
-        $this->setCacheDir(null);
+        if (!isset($options['cacheDir'])) {
+            $this->setCacheDir(null);
+        }
 
         parent::__construct($options);
     }


### PR DESCRIPTION
Do not set cacheDir null if cacheDir exists in $options (it will be set properly in parent constructor)
Reason: some systems may have access to path from sys_get_temp_dir() disabled ( error 500 )
